### PR TITLE
Fixed ordering of group file in SMMAT.meta

### DIFF
--- a/R/SMMAT.R
+++ b/R/SMMAT.R
@@ -400,7 +400,7 @@ SMMAT.meta <- function(meta.files.prefix, n.files = rep(1, length(meta.files.pre
     groups <- unique(group.info$group)
     n.groups <- length(groups)
     group.info$group.idx <- as.numeric(factor(group.info$group))
-    group.info <- group.info[order(group.info$group.idx), ]
+    group.info <- group.info[order(group.info$group.idx, group.info$chr, group.info$pos), ]
     group.idx.end <- findInterval(1:n.groups, group.info$group.idx)
     group.idx.start <- c(1, group.idx.end[-n.groups] + 1)
     variant.id <- paste(group.info$group, group.info$chr, group.info$pos, group.info$ref, group.info$alt, sep = ":")


### PR DESCRIPTION
SMMAT orders the group file by group name (ordered by as.factor), then by an implicit chr:pos order (l.84). This is incoherent with the ordering in SMMAT.meta, which is only by group name. This only works when the group file is ordered by group, then chr:pos already, and if this order is left untouched by order(group.info$group.idx). Otherwise the error at l. 432 is triggered. Has now been changed to add explicit chr:pos ordering in SMMAT.meta. SMMAT now supports randomly ordered group files.